### PR TITLE
Obstacle avoidance changes + action server name change + action status

### DIFF
--- a/include/napoleon_config.h
+++ b/include/napoleon_config.h
@@ -32,8 +32,8 @@ static constexpr double SIZE_FRONT_ROPOD = ROPOD_LENGTH/2.0;  // How long ropod 
     static constexpr double ENV_TRNS_SIZE_CORNERING = 0.45; // d_trnsc Transition area size while cornering [m]
     static constexpr double V_CRUISING = 1.2;//1.4;           // Max velocity [m/s] while cruising
     static constexpr double V_INTER_TURNING = 0.5;//0.5;      // Max velocity [m/s] when taking a turn
-    static constexpr double V_INTER_ACC = 0.8;//0.7;          // Max velocity [m/s] when driving straight at intersection
-    static constexpr double V_INTER_DEC = 0.8;//0.3;          // Max velocity [m/s] when driving straight at intersection
+    static constexpr double V_INTER_ACC = V_INTER_TURNING;//0.7;          // Max velocity [m/s] when driving straight at intersection
+    static constexpr double V_INTER_DEC = V_INTER_TURNING;//0.3;          // Max velocity [m/s] when driving straight at intersection
     static constexpr double V_ENTRY = 0.5;//0.5;              // Max velocity [m/s] when at entry of intersection
     static constexpr double V_STEERSATURATION = 0.4;    // Velocity during steering saturation [m/s]
     static constexpr double V_OVERTAKE = 1.0;//0.5;           // Velocity during overtaking [m/s]
@@ -48,7 +48,7 @@ static constexpr double SIZE_FRONT_ROPOD = ROPOD_LENGTH/2.0;  // How long ropod 
     static constexpr double ROTATED_ENOUGH_TRES = M_PI/3;   // Stop turning when within x rad of the new corridor
 #else
     static constexpr double FEELER_SIZE = 2.0;          // d_f: 0.5 Size of feeler [m] - used to predict where ropod goes suppose it would go straight
-    static constexpr double FEELER_SIZE_STEERING = 3.0; // df_c: 0.3 Size of feeler when steering [m]
+    static constexpr double FEELER_SIZE_STEERING = 2.5; // df_c: 0.3 Size of feeler when steering [m]
     static constexpr double ENV_TCTW_SIZE = 0.05;       // d_cor 0.05 Too close too wall area size [m]
     static constexpr double ENV_TRNS_SIZE = 0.20;       // d_trns 0.2 Transition area size [m]
     static constexpr double CARROT_LENGTH = FEELER_SIZE+0.5;       // How far ahead point lies where ropod steers towards when too close to a wall [m]
@@ -57,23 +57,23 @@ static constexpr double SIZE_FRONT_ROPOD = ROPOD_LENGTH/2.0;  // How long ropod 
     static constexpr double ROPOD_TO_AX = 0;       // Length from rear axle to ropod center [m] (without load).
     static constexpr double SIZE_REAR = ROPOD_LENGTH/2; // How far vehicle extends behind rear axle (witho
     // Optimization / performance parameters
-    static constexpr double ENV_TRNS_SIZE_CORNERING = 0.45; // d_trnsc Transition area size while cornering [m]
+    static constexpr double ENV_TRNS_SIZE_CORNERING = 0.3; // d_trnsc Transition area size while cornering [m]
     static constexpr double V_CRUISING = 1.1;//1.4;           // Max velocity [m/s] while cruising
     static constexpr double V_INTER_TURNING = 0.6;//0.5;      // Max velocity [m/s] when taking a turn
-    static constexpr double V_INTER_ACC = V_CRUISING;//0.7;          // Max velocity [m/s] when driving straight at intersection
-    static constexpr double V_INTER_DEC = 0.6;//0.3;          // Max velocity [m/s] when driving straight at intersection
+    static constexpr double V_INTER_ACC = V_INTER_TURNING;//0.7;          // Max velocity [m/s] when driving straight at intersection
+    static constexpr double V_INTER_DEC = V_INTER_TURNING;//0.3;          // Max velocity [m/s] when driving straight at intersection
     static constexpr double V_ENTRY = 0.6;//0.5;              // Max velocity [m/s] when at entry of intersection
     static constexpr double V_STEERSATURATION = 0.4;          // Velocity during steering saturation [m/s]
     static constexpr double V_OVERTAKE = 0.8*V_CRUISING;//0.5;           // Velocity during overtaking [m/s]
     // Limits
-    static constexpr double DELTA_DOT_LIMIT = 0.3;   // Max steering rate per second [rad/s]
+    static constexpr double DELTA_DOT_LIMIT = 0.5;   // Max steering rate per second [rad/s]
     static constexpr double A_MAX = 0.7;                    // Maximum acceleration magnitude [m/s^2]
     // Obstacle
     static constexpr double V_OBS_OVERTAKE_MAX = 0.1;       // Max speed an obstacle can have to overtake is [m/s]
     static constexpr double MIN_DIST_TO_OVERTAKE = 2.5;     // Don't start earlier than x meters to overtake [m]
     // Performance based on position in environment
-    static constexpr double START_STEERING_EARLY = 0.1;     // Start steering earlier by x [m]
-    static constexpr double ROTATED_ENOUGH_TRES = 0.8*M_PI/4;   // Stop turning when within x rad of the new corridor
+    static constexpr double START_STEERING_EARLY = 0.0;     // Start steering earlier by x [m]
+    static constexpr double ROTATED_ENOUGH_TRES = 1.2*M_PI/4;   // Stop turning when within x rad of the new corridor
 #endif
 
 static constexpr double SIZE_FRONT_RAX = (ROPOD_TO_AX + SIZE_FRONT_ROPOD); // How far vehicle extends in front of rear axle
@@ -95,12 +95,12 @@ static constexpr double T_MAX_PRED = 20;            // Predict for n seconds max
 static constexpr double CUTOFF_FREQ = 1.0;          // Cutoff frequency for low pass filter to simulate steering delay [Hz]
 static const vector<double> V_SCALE_OPTIONS = {1.0, 0.67, 0.33, 0.0};  // Options to scale velocity with
 static constexpr double ENV_COR_WIDTH = 2.6;
-static constexpr double OBS_AVOID_MARGIN = 0.1;         // Margin between ropod and obstacles at full speed [m]
+static constexpr double OBS_AVOID_MARGIN = 0.05;         // Margin between ropod and obstacles at full speed [m]
 static constexpr double OBS_AVOID_MARGIN_FRONT = 0.15;         // Margin between ropod front and obstacles at full speed [m]
 static constexpr double DILATE_ROPOD_ALIGNING = 0.90;   // Dilation from center (so actually this value -size_side if measured from side of vehicle)
 // Fictional hallway width. Ropod will work with lanes of this/2 [m], starting from the wall.
 // No matter what the real hallway size is. This way it will stay close to the right wall, but not too agressively.
-static constexpr double TUBE_WIDTH_C = 2.0*(ENV_TCTW_SIZE+ENV_TRNS_SIZE+SIZE_SIDE+OBS_AVOID_MARGIN)+0.1; // Default tube width [m]
+static constexpr double TUBE_WIDTH_C = 2.0*(SIZE_SIDE+ENV_TCTW_SIZE + fmax(ENV_TRNS_SIZE,OBS_AVOID_MARGIN)); // Default tube width [m]
 static constexpr double REACHEDTARGETTRESHOLD = 2.0;  // When x [m] removed from center of last hallway, program finished
 
 // Performance based on position in environment

--- a/include/napoleon_config.h
+++ b/include/napoleon_config.h
@@ -42,7 +42,7 @@ static constexpr double SIZE_FRONT_ROPOD = ROPOD_LENGTH/2.0;  // How long ropod 
     static constexpr double A_MAX = 0.5;                    // Maximum acceleration magnitude [m/s^2]
     // Obstacle
     static constexpr double V_OBS_OVERTAKE_MAX = 0.1;       // Max speed an obstacle can have to overtake is [m/s]
-    static constexpr double MIN_DIST_TO_OVERTAKE = 2.5;     // Don't start earlier than x meters to overtake [m]
+    static constexpr double MIN_DIST_TO_OVERTAKE = 3.0;     // Don't start earlier than x meters to overtake [m]
     // Performance based on position in environment
     static constexpr double START_STEERING_EARLY = 0.6;     // Start steering earlier by x [m]
     static constexpr double ROTATED_ENOUGH_TRES = M_PI/3;   // Stop turning when within x rad of the new corridor
@@ -95,16 +95,16 @@ static constexpr double T_MAX_PRED = 20;            // Predict for n seconds max
 static constexpr double CUTOFF_FREQ = 1.0;          // Cutoff frequency for low pass filter to simulate steering delay [Hz]
 static const vector<double> V_SCALE_OPTIONS = {1.0, 0.67, 0.33, 0.0};  // Options to scale velocity with
 static constexpr double ENV_COR_WIDTH = 2.6;
+static constexpr double OBS_AVOID_MARGIN = 0.1;         // Margin between ropod and obstacles at full speed [m]
+static constexpr double OBS_AVOID_MARGIN_FRONT = 0.15;         // Margin between ropod front and obstacles at full speed [m]
+static constexpr double DILATE_ROPOD_ALIGNING = 0.90;   // Dilation from center (so actually this value -size_side if measured from side of vehicle)
 // Fictional hallway width. Ropod will work with lanes of this/2 [m], starting from the wall.
 // No matter what the real hallway size is. This way it will stay close to the right wall, but not too agressively.
-static constexpr double TUBE_WIDTH_C = 2.0*(ENV_TCTW_SIZE+ENV_TRNS_SIZE+SIZE_SIDE)+0.1; // Default tube width [m]
+static constexpr double TUBE_WIDTH_C = 2.0*(ENV_TCTW_SIZE+ENV_TRNS_SIZE+SIZE_SIDE+OBS_AVOID_MARGIN)+0.1; // Default tube width [m]
 static constexpr double REACHEDTARGETTRESHOLD = 2.0;  // When x [m] removed from center of last hallway, program finished
 
 // Performance based on position in environment
 static constexpr double ENTRY_LENGTH = 2.0;             // Length of entries before intersections [m]
-static constexpr double OBS_AVOID_MARGIN = 0.05;         // Margin between ropod and obstacles at full speed [m]
-static constexpr double OBS_AVOID_MARGIN_FRONT = 0.15;         // Margin between ropod front and obstacles at full speed [m]
-static constexpr double DILATE_ROPOD_ALIGNING = 0.90;   // Dilation from center (so actually this value -size_side if measured from side of vehicle)
 //static constexpr double ROPOD_TO_OBS_MARGIN = (OBS_AVOID_MARGIN+SIZE_FRONT_ROPOD)/SIZE_FRONT_ROPOD;
 static constexpr double SHARP_ANGLE_TRESHOLD = 0.1;     // Angle how much the next hallway must be sharper than perpendicular to be considered sharp [rad]
 

--- a/include/napoleon_config.h
+++ b/include/napoleon_config.h
@@ -72,7 +72,7 @@ static constexpr double SIZE_FRONT_ROPOD = ROPOD_LENGTH/2.0;  // How long ropod 
     static constexpr double V_OBS_OVERTAKE_MAX = 0.1;       // Max speed an obstacle can have to overtake is [m/s]
     static constexpr double MIN_DIST_TO_OVERTAKE = 2.5;     // Don't start earlier than x meters to overtake [m]
     // Performance based on position in environment
-    static constexpr double START_STEERING_EARLY = 0.1;     // Start steering earlier by x [m]
+    static constexpr double START_STEERING_EARLY = 0.3;     // Start steering earlier by x [m]
     static constexpr double ROTATED_ENOUGH_TRES = 0.8*M_PI/4;   // Stop turning when within x rad of the new corridor
 #endif
 

--- a/include/napoleon_functions.h
+++ b/include/napoleon_functions.h
@@ -13,6 +13,7 @@ static constexpr double     _PI= 3.141592653589793238462643383279502884197169399
 static constexpr double _TWO_PI= 6.2831853071795864769252867665590057683943387987502116419498891846156328125724179972560696;
 
 void printstringvec(vector<string> vec);
+Point getPoint(PointID point_with_id);
 Point rotate_point(Point c, double angle, Point p);
 Point coordGlobalToRopod(Point gp, Point rc, double ra);
 Point coordGlobalToRopod(PointID gp, Point rc, double ra);
@@ -23,6 +24,9 @@ double dist2(Point v, Point w);
 double distToSegmentSquared(Point p, Point v, Point w);
 double distToEndSegmentSquared(Point p, Point v, Point w);
 double distToEndSegmentSquared(Point p, PointID v, PointID w);
+bool isPointOnLeftSide(string p_rearID, string p_frontID, vector<PointID> pointlist, Point point, double max_dist);
+double perpDistToSegment(Point p, PointID v, PointID w);
+double perpDistToSegment(Point p, Point v, Point w);
 double distToSegment(Point p, PointID v, PointID w);
 double distToSegment(Point p, Point v, Point w);
 double distToLine(Point p, PointID v, PointID w);

--- a/include/napoleon_functions.h
+++ b/include/napoleon_functions.h
@@ -43,10 +43,9 @@ PointID getPointByID(string wantedID, vector<PointID> pointlist);
 vector<string> getPointsForTurning(AreaQuadID OBJ1, AreaQuadID OBJ2, AreaQuadID OBJ3, vector<string> OBJ1TASK);
 vector<string> getWalls(int id_OBJ1, int id_OBJ2, int id_OBJ3, vector<AreaQuadID> arealist);
 
-double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, double tubewidth);
-double getSteeringTurn(Point local_pivot, bool dir_cw, Point local_wallpoint_front, Point local_wallpoint_rear);
-
-double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std::vector<string> task, vector<PointID> pointlist);
+double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, double tubewidth, double carrot_length, double feeler_size);
+double getSteeringTurn(Point local_pivot, bool dir_cw, Point local_wallpoint_front, Point local_wallpoint_rear, double carrot_length, double feeler_size);
+double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std::vector<string> task, vector<PointID> pointlist, double carrot_length, double feeler_size_steering);
 
 double wrapToPi(double angle);
 double modf(double x, double y);

--- a/include/napoleon_geometry.h
+++ b/include/napoleon_geometry.h
@@ -37,6 +37,16 @@ public:
     bool contains(Point q);
 };
 
+
+class Rectangle {
+public:
+    double width;
+    double depth;
+    double x;
+    double y;
+};
+
+
 class AreaQuadID {
 public:
     PointID p0, p1, p2, p3;

--- a/launch/napoleon_navigation_ropod_experiment.launch
+++ b/launch/napoleon_navigation_ropod_experiment.launch
@@ -10,16 +10,14 @@
 <!--
          <arg name="map_file" default="$(find ed_object_models)/models/tue_hallway_RLtoAL/walls/shape/map.yaml" />
 -->
-       <arg name="map_file" default="/home/cesar/ropod-project-software/catkin_workspace/src/applications/occupancy_grids/brsu/brsu-c-floor0_osm/map.yaml" />
+       <arg name="map_file" default="/home/ropod/ropod-project-software/catkin_workspace/src/applications/occupancy_grids/brsu/brsu-c-floor0_osm/map.yaml" />
 
    <!-- Run the map server -->
      <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
 
     <!--- Run AMCL -->
     <node pkg="amcl" type="amcl" name="amcl">
-        <remap from="scan" to="/$(arg robotName)/$(arg laser1_name)/scan"/>
-        
-        <!-- <remap from="scan" to="/projected_scan_front"/> --> <!-- for BRSU ropod -->
+        <remap from="scan" to="/projected_scan_front"/> <!-- for BRSU ropod -->
 
         <!--- Odometery model parameters  -->
         <param name="odom_model_type" value="omni"/>
@@ -91,7 +89,7 @@
         <remap from="/napoleon_navigation/cmd_vel" to="/load/cmd_vel"/>
         <!-- On ropod: -->
         <!--<remap from="/napoleon_navigation/cmd_vel" to="/ropod_tue_1/cmd_vel"/>-->
-        <remap from="/napoleon_navigation/scan" to="/$(arg robotName)/$(arg laser1_name)/scan"/>
+        <remap from="/napoleon_navigation/scan" to="/projected_scan_front"/> <!-- for BRSU ropod -->
 
     </node>
 

--- a/launch/napoleon_navigation_tue_plus_perception.launch
+++ b/launch/napoleon_navigation_tue_plus_perception.launch
@@ -2,7 +2,7 @@
 <launch>
 
 
-  	<arg name="robotName" default="ropod_tue_2"/>
+  	<arg name="robotName" default="ropod"/>
 	<arg name="laser1_name" value ="laser"/>
         <!--<arg name="map_file" default="$(find ed_object_models)/models/hospital_test_amcl/walls/map_amcl.yaml" />-->
 	<!--<arg name="map_file" default="$(find ropod_navigation_test)/config/amk-f064/map.yaml"/>-->
@@ -17,7 +17,7 @@
 
     <!--- Run AMCL -->
     <node pkg="amcl" type="amcl" name="amcl">
-        <remap from="scan" to="/$(arg robotName)/$(arg laser1_name)/scan_filtered"/>
+        <remap from="scan" to="/$(arg robotName)/$(arg laser1_name)/scan"/>
         
         <!-- <remap from="scan" to="/projected_scan_front"/> --> <!-- for BRSU ropod -->
 
@@ -62,9 +62,9 @@
 
         <!-- initial pose of the robot in TU/e hallway-->
 
-        <param name="initial_pose_x" value="4.6"/>
-        <param name="initial_pose_y" value="7.8"/>
-        <param name="initial_pose_a" value="-1.54"/>
+        <param name="initial_pose_x" value="9.1"/>
+        <param name="initial_pose_y" value="7.3"/>
+        <param name="initial_pose_a" value="-3.14"/>
 
 
         <!-- initial pose of the robot in BRSU-->
@@ -94,7 +94,7 @@
         <!-- On ropod: -->
         <!--<remap from="/napoleon_navigation/cmd_vel" to="/ropod_tue_1/cmd_vel"/>-->
         <remap from="/napoleon_navigation/odom" to="/$(arg robotName)/odom"/>
-        <remap from="/napoleon_navigation/scan" to="/$(arg robotName)/$(arg laser1_name)/scan_filtered"/>
+        <remap from="/napoleon_navigation/scan" to="/$(arg robotName)/$(arg laser1_name)/scan"/>
 
     </node>
 

--- a/launch/napoleon_navigation_tue_plus_perception.launch
+++ b/launch/napoleon_navigation_tue_plus_perception.launch
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<launch>
+
+
+  	<arg name="robotName" default="ropod_tue_2"/>
+	<arg name="laser1_name" value ="laser"/>
+        <!--<arg name="map_file" default="$(find ed_object_models)/models/hospital_test_amcl/walls/map_amcl.yaml" />-->
+	<!--<arg name="map_file" default="$(find ropod_navigation_test)/config/amk-f064/map.yaml"/>-->
+        <!--<arg name="map_file" default="/home/cesar/ropod-project-software/catkin_workspace/src/applications/occupancy_grids/tue/lab-level/map.yaml"/>-->
+
+         <arg name="map_file" default="$(find ed_object_models)/models/tue_hallway_RLtoAL/walls/shape/map.yaml" />
+
+      <!-- <arg name="map_file" default="/home/ropod/ropod-project-software/catkin_workspace/src/applications/occupancy_grids/brsu/brsu-c-floor0_osm/map.yaml" />  -->
+ 
+   <!-- Run the map server -->
+     <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)" />
+
+    <!--- Run AMCL -->
+    <node pkg="amcl" type="amcl" name="amcl">
+        <remap from="scan" to="/$(arg robotName)/$(arg laser1_name)/scan_filtered"/>
+        
+        <!-- <remap from="scan" to="/projected_scan_front"/> --> <!-- for BRSU ropod -->
+
+        <!--- Odometery model parameters  -->
+        <param name="odom_model_type" value="omni"/>
+        <param name="odom_alpha1" value="7.0"/>
+        <param name="odom_alpha2" value="5.0"/>
+        <param name="odom_alpha3" value="5.0"/>
+        <param name="odom_alpha4" value="5.0"/>
+        <param name="odom_alpha5" value="7.0"/>
+        <param name="odom_frame_id" value="$(arg robotName)/odom"/>
+        <param name="base_frame_id" value="$(arg robotName)/base_link"/>
+        <param name="global_frame_id" value="/map"/>
+
+        <!-- Overall filter parameters -->
+        <param name="min_particles" value="200"/>
+        <param name="max_particles" value="1000"/>
+        <param name="kld_err" value="0.01"/>
+        <param name="kld_z" value="0.99"/>
+        <param name="update_min_d" value="0.05"/>
+        <param name="update_min_a" value="0.01"/>
+        <param name="resample_interval" value="2"/>
+        <param name="transform_tolerance" value="0.1" />
+        <param name="recovery_alpha_slow" value="0.0"/>
+        <param name="recovery_alpha_fast" value="0.0"/>
+        <param name="gui_publish_rate" value="-1"/>
+        <param name="use_map_topic" value="true"/>
+        <param name="first_map_only" value="true"/>
+
+        <!--Laser model parameters -->
+        <param name="laser_min_range" value="0.04"/>
+        <param name="laser_max_range" value="5.0"/>
+        <param name="laser_max_beams" value="30"/>
+        <param name="laser_z_hit" value="0.95"/>
+        <param name="laser_z_short" value="0.01"/>
+        <param name="laser_z_max" value="0.05"/>
+        <param name="laser_z_rand" value="0.05"/>
+        <param name="laser_sigma_hit" value="0.2"/>
+        <param name="laser_lambda_short" value="0.1"/>
+        <param name="laser_likelihood_max_dist" value="1.0"/>
+        <param name="laser_model_type" value="likelihood_field"/>
+
+        <!-- initial pose of the robot in TU/e hallway-->
+
+        <param name="initial_pose_x" value="4.6"/>
+        <param name="initial_pose_y" value="7.8"/>
+        <param name="initial_pose_a" value="-1.54"/>
+
+
+        <!-- initial pose of the robot in BRSU-->
+        <!--       
+        <param name="initial_pose_x" value="59.74"/>
+        <param name="initial_pose_y" value="32.36"/>
+        <param name="initial_pose_a" value="-3.14"/>
+        -->
+
+    </node>
+
+    % Launch ED
+   <!-- <node pkg="ed" type="ed" name="ed" args="$(find ropod_navigation_test)/config/model-example-ropod-napoleon-ynavigation-ED.yaml"/> -->
+    <!-- <node pkg="ed" type="ed" name="ed" args="$(find ropod_navigation_test)/config/model-example-ropod-napoleon-ynavigation-ED.yaml" launch-prefix="xterm -e gdb -_-args"/>-->
+
+    <node name="napoleon_navigation" pkg="napoleon_navigation" type="napoleon_navigation" output="screen">
+
+        <rosparam file="$(find ropod_navigation_test)/config/parameters/costmap_common_params.yaml" command="load" ns="local_costmap" />
+        <rosparam file="$(find ropod_navigation_test)/config/parameters/footprint_ropod.yaml" command="load" ns="local_costmap" />
+        <rosparam file="$(find ropod_navigation_test)/config/parameters/local_costmap_params.yaml"  command="load"/>
+        <rosparam file="$(find ropod_navigation_test)/config/parameters/teb_local_planner_params_ropod.yaml" command="load" />
+        <param name="default_ropod_navigation_param_file" value ="$(find napoleon_navigation)/config/footprint_local_planner_params_ropod.yaml"/>
+        <param name="default_ropod_load_navigation_param_file" value ="$(find napoleon_navigation)/config/footprint_local_planner_params_ropod_load.yaml"/>
+
+        <!-- In Gazebo: -->
+        <remap from="/napoleon_navigation/cmd_vel" to="/$(arg robotName)/load/cmd_vel"/>
+        <!-- On ropod: -->
+        <!--<remap from="/napoleon_navigation/cmd_vel" to="/ropod_tue_1/cmd_vel"/>-->
+        <remap from="/napoleon_navigation/odom" to="/$(arg robotName)/odom"/>
+        <remap from="/napoleon_navigation/scan" to="/$(arg robotName)/$(arg laser1_name)/scan_filtered"/>
+
+    </node>
+
+
+</launch>

--- a/src/napoleon_functions.cpp
+++ b/src/napoleon_functions.cpp
@@ -61,12 +61,12 @@ Point coordGlobalToRopod(Point gp, Point rc, double ra)
     return P;
 }
 
-double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, double tubewidth)
+double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, double tubewidth, double carrot_length, double feeler_size)
 {
     // Function to determine steering action while cruising
     // ROPOD_LENGTH the length of the ropod[m]
     // SIZE_SIDE is the distance from the center to the side of the vehicle[m]
-    // FEELER_SIZE is the length of the feeler, extending in front of the ropod
+    // feeler_size is the length of the feeler, extending in front of the ropod
     // and triggering behavior changes - positioned above tr(top right) and tl[m]
     // local_wallpoint_front: point on right wall is a point that is to the
     // right of the ropod, can be any point(x, y) format[m]
@@ -76,20 +76,20 @@ double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, doub
     // tubewidth is the tube width [m]
     // ENV_TCTW_SIZE is the distance when the ropod is too close to the wall[m]
     // ENV_TRNS_SIZE is the size of the transition area(starting from tctw)[m]
-    // CARROT_LENGTH is how aggressive the ropod steers to the middle, it is
+    // carrot_length is how aggressive the ropod steers to the middle, it is
     // the scale for the vector that points forward from the middle of the road,
     // the bigger this value, the less aggressive the steering action[m]
     // fimdf: feelers in motion direction fraction, this determines whether
     // the feelers are pointed in the same direction as the wheels[1] or
     // just in front of the ropod[0] or something in between[0, 1]
-    if (tubewidth < 2 * (SIZE_SIDE + ENV_TCTW_SIZE + ENV_TRNS_SIZE))
+    if (tubewidth < 2 * (SIZE_SIDE + ENV_TCTW_SIZE + ENV_TRNS_SIZE + OBS_AVOID_MARGIN))
     {
         cout << "Corridor too small, or transition and correction zone too big" << endl;
     }
 
     // Feelers in front of the ropod
-    Point local_fl(ROPOD_LENGTH / 2 + FEELER_SIZE, SIZE_SIDE);
-    Point local_fr(ROPOD_LENGTH / 2 + FEELER_SIZE, -SIZE_SIDE);
+    Point local_fl(ROPOD_LENGTH / 2 + feeler_size, SIZE_SIDE);
+    Point local_fr(ROPOD_LENGTH / 2 + feeler_size, -SIZE_SIDE);
     Point origin(0,0);
 
     double local_wall_angle = atan2(local_wallpoint_front.y - local_wallpoint_rear.y, local_wallpoint_front.x - local_wallpoint_rear.x);
@@ -113,7 +113,7 @@ double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, doub
 
     double to_middle_size = tubewidth/2 - dist_ropod_center_to_rightwall;                   // Y Distance from ropod center to middle of road @ env at theta = 0
     double to_middle_vec[2] = { to_middle_size * -sin(local_wall_angle), to_middle_size * cos(local_wall_angle) };  // Vector from ropod center to middle of road
-    double to_front_vec[2] = { CARROT_LENGTH * cos(local_wall_angle), CARROT_LENGTH*sin(local_wall_angle) };    // Vector from middle of road to a point further on the road
+    double to_front_vec[2] = { carrot_length * cos(local_wall_angle), carrot_length*sin(local_wall_angle) };    // Vector from middle of road to a point further on the road
     double steer_vec[2] = { to_front_vec[0] + to_middle_vec[0], to_front_vec[1] + to_middle_vec[1] };               // Together, these vectors form the steering vector
 
     // Phi_0 can be used when we are comfortably within the middle of the road
@@ -164,7 +164,7 @@ double getSteering(Point local_wallpoint_front, Point local_wallpoint_rear, doub
     return phi;
 }
 
-double getSteeringTurn(Point local_pivot, bool dir_cw, Point local_wallpoint_front, Point local_wallpoint_rear) {
+double getSteeringTurn(Point local_pivot, bool dir_cw, Point local_wallpoint_front, Point local_wallpoint_rear, double carrot_length, double feeler_size) {
     // Function to determine steering action while rotating around a point
     // aka taking a turn
     // dir_cw: direction 0 = CCW, 1 = CW rotation
@@ -176,8 +176,8 @@ double getSteeringTurn(Point local_pivot, bool dir_cw, Point local_wallpoint_fro
     double dist = 0, phi = 0, to_middle_size = 0;
 
     double phi_0 = steerAroundPoint(local_pivot, dir_cw);
-    Point local_fl(FEELER_SIZE*cos(phi_0),FEELER_SIZE*sin(phi_0));
-    Point local_fr(FEELER_SIZE*cos(phi_0),FEELER_SIZE*sin(phi_0));
+    Point local_fl(feeler_size*cos(phi_0),feeler_size*sin(phi_0));
+    Point local_fr(feeler_size*cos(phi_0),feeler_size*sin(phi_0));
     local_fl = local_fl.add(local_lt);
     local_fr = local_fr.add(local_rt);
 
@@ -203,7 +203,7 @@ double getSteeringTurn(Point local_pivot, bool dir_cw, Point local_wallpoint_fro
         // to_middle_size = tubewidth/2-dist_ropod_center_to_wall;
     }
     Point to_middle_vec(to_middle_size*-sin(local_wall_angle),to_middle_size*cos(local_wall_angle));
-    Point to_front_vec(CARROT_LENGTH*cos(local_wall_angle), CARROT_LENGTH*sin(local_wall_angle));  // Vector from middle of road to a point further on the road
+    Point to_front_vec(carrot_length*cos(local_wall_angle), carrot_length*sin(local_wall_angle));  // Vector from middle of road to a point further on the road
     Point steer_vec(to_front_vec.x + to_middle_vec.x, to_front_vec.y + to_middle_vec.y);
     //steer_vec = steer_vec.add(to_middle_vec); // Together, these vectors form the steering vector
 
@@ -954,7 +954,7 @@ vector<string> getWalls(int id_OBJ1, int id_OBJ2, int id_OBJ3, vector<AreaQuadID
     return wallsABC;
 }
 
-double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std::vector<string> task, vector<PointID> pointlist) {
+double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std::vector<string> task, vector<PointID> pointlist, double carrot_length, double feeler_size_steering) {
     // NOT IN LOCAL COORDINATES (YET)
     // Function to determine steering action while rotating around a point
     // aka taking a turn, this time with a sharp angle.
@@ -983,8 +983,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
              y_rearax+(D_AX+SIZE_FRONT_ROPOD)*sin(ropod_angle)+SIZE_SIDE*sin(ropod_angle-M_PI/2));
     Point lt(x_rearax+(D_AX+SIZE_FRONT_ROPOD)*cos(ropod_angle)+SIZE_SIDE*cos(ropod_angle+M_PI/2),
              y_rearax+(D_AX+SIZE_FRONT_ROPOD)*sin(ropod_angle)+SIZE_SIDE*sin(ropod_angle+M_PI/2));
-    Point fr(FEELER_SIZE_STEERING*cos(ropod_angle+phi_0),FEELER_SIZE_STEERING*sin(ropod_angle+phi_0));
-    Point fl(FEELER_SIZE_STEERING*cos(ropod_angle+phi_0),FEELER_SIZE_STEERING*sin(ropod_angle+phi_0));
+    Point fr(feeler_size_steering*cos(ropod_angle+phi_0),feeler_size_steering*sin(ropod_angle+phi_0));
+    Point fl(feeler_size_steering*cos(ropod_angle+phi_0),feeler_size_steering*sin(ropod_angle+phi_0));
     fr = fr.add(rt); fl = fl.add(lt);
 
     Point obj3_wall_to_fl = rotate_point(obj3wall_p0_idless, -obj3wall_angle, fl);
@@ -1020,8 +1020,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj3_wall_to_ropod = obj3_wall_to_ropod.sub(obj3wall_p0_idless);
             to_middle_vec.x = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*-sin(obj3wall_angle);
             to_middle_vec.y = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*cos(obj3wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj3wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj3wall_angle);
+            to_front_vec.x = carrot_length*cos(obj3wall_angle);
+            to_front_vec.y = carrot_length*sin(obj3wall_angle);
             frac_in_trans = 1;
         } else if (obj2_wall_to_feeler > -ENV_TCTW_SIZE) {
             //disp('tctw obj2');
@@ -1029,8 +1029,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj2_wall_to_ropod = obj2_wall_to_ropod.sub(obj2wall_p0_idless);
             to_middle_vec.x = (-FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*-sin(obj2wall_angle);
             to_middle_vec.y = (-FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*cos(obj2wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj2wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj2wall_angle);
+            to_front_vec.x = carrot_length*cos(obj2wall_angle);
+            to_front_vec.y = carrot_length*sin(obj2wall_angle);
             frac_in_trans = 1;
         } else if (obj3_wall_to_feeler > -(ENV_TCTW_SIZE+ENV_TRNS_SIZE_CORNERING)) {
             //disp('trans obj3');
@@ -1038,8 +1038,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj3_wall_to_ropod = obj3_wall_to_ropod.sub(obj3wall_p0_idless);
             to_middle_vec.x = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*-sin(obj3wall_angle);
             to_middle_vec.y = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*cos(obj3wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj3wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj3wall_angle);
+            to_front_vec.x = carrot_length*cos(obj3wall_angle);
+            to_front_vec.y = carrot_length*sin(obj3wall_angle);
             frac_in_trans = 1-(-obj3_wall_to_feeler-ENV_TCTW_SIZE)/ENV_TRNS_SIZE_CORNERING;
         } else if (obj2_wall_to_feeler > -(ENV_TCTW_SIZE+ENV_TRNS_SIZE_CORNERING)) {
             //disp('trans obj2');
@@ -1047,8 +1047,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj2_wall_to_ropod = obj2_wall_to_ropod.sub(obj2wall_p0_idless);
             to_middle_vec.x = (-FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*-sin(obj2wall_angle);
             to_middle_vec.y = (-FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*cos(obj2wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj2wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj2wall_angle);
+            to_front_vec.x = carrot_length*cos(obj2wall_angle);
+            to_front_vec.y = carrot_length*sin(obj2wall_angle);
             frac_in_trans = 1-(-obj2_wall_to_feeler-ENV_TCTW_SIZE)/ENV_TRNS_SIZE_CORNERING;
         } else {
             //disp('normal cornering');
@@ -1056,8 +1056,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj3_wall_to_ropod = obj3_wall_to_ropod.sub(obj3wall_p0_idless);
             to_middle_vec.x = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*-sin(obj3wall_angle);
             to_middle_vec.y = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*cos(obj3wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj3wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj3wall_angle);
+            to_front_vec.x = carrot_length*cos(obj3wall_angle);
+            to_front_vec.y = carrot_length*sin(obj3wall_angle);
             frac_in_trans = 0;
         }
     } else {
@@ -1067,8 +1067,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj3_wall_to_ropod = obj3_wall_to_ropod.sub(obj3wall_p0_idless);
             to_middle_vec.x = (FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*-sin(obj3wall_angle);
             to_middle_vec.y = (FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*cos(obj3wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj3wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj3wall_angle);
+            to_front_vec.x = carrot_length*cos(obj3wall_angle);
+            to_front_vec.y = carrot_length*sin(obj3wall_angle);
             frac_in_trans = 1;
         } else if (obj2_wall_to_feeler < ENV_TCTW_SIZE) {
             //disp('tctw obj2');
@@ -1076,8 +1076,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj2_wall_to_ropod = obj2_wall_to_ropod.sub(obj2wall_p0_idless);
             to_middle_vec.x = (FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*-sin(obj2wall_angle);
             to_middle_vec.y = (FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*cos(obj2wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj2wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj2wall_angle);
+            to_front_vec.x = carrot_length*cos(obj2wall_angle);
+            to_front_vec.y = carrot_length*sin(obj2wall_angle);
             frac_in_trans = 1;
         } else if (obj3_wall_to_feeler < (ENV_TCTW_SIZE+ENV_TRNS_SIZE_CORNERING)) {
             //disp('trans obj3');
@@ -1085,8 +1085,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj3_wall_to_ropod = obj3_wall_to_ropod.sub(obj3wall_p0_idless);
             to_middle_vec.x = (FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*-sin(obj3wall_angle);
             to_middle_vec.y = (FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*cos(obj3wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj3wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj3wall_angle);
+            to_front_vec.x = carrot_length*cos(obj3wall_angle);
+            to_front_vec.y = carrot_length*sin(obj3wall_angle);
             frac_in_trans = 1-(obj3_wall_to_feeler-ENV_TCTW_SIZE)/ENV_TRNS_SIZE_CORNERING;
         } else if (obj2_wall_to_feeler < (ENV_TCTW_SIZE+ENV_TRNS_SIZE_CORNERING)) {
             //disp('trans obj2');
@@ -1094,8 +1094,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj2_wall_to_ropod = obj2_wall_to_ropod.sub(obj2wall_p0_idless);
             to_middle_vec.x = (FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*-sin(obj2wall_angle);
             to_middle_vec.y = (FOLLOW_WALL_DIST_TURNING-obj2_wall_to_ropod.y)*cos(obj2wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj2wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj2wall_angle);
+            to_front_vec.x = carrot_length*cos(obj2wall_angle);
+            to_front_vec.y = carrot_length*sin(obj2wall_angle);
             frac_in_trans = 1-(obj2_wall_to_feeler-ENV_TCTW_SIZE)/ENV_TRNS_SIZE_CORNERING;
         } else {
             //disp('normal cornering');
@@ -1103,8 +1103,8 @@ double getSteeringTurnSharp(Point ropodpos, double ropod_angle, bool dir_cw, std
             obj3_wall_to_ropod = obj3_wall_to_ropod.sub(obj3wall_p0_idless);
             to_middle_vec.x = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*-sin(obj3wall_angle);
             to_middle_vec.y = (-FOLLOW_WALL_DIST_TURNING-obj3_wall_to_ropod.y)*cos(obj3wall_angle);
-            to_front_vec.x = CARROT_LENGTH*cos(obj3wall_angle);
-            to_front_vec.y = CARROT_LENGTH*sin(obj3wall_angle);
+            to_front_vec.x = carrot_length*cos(obj3wall_angle);
+            to_front_vec.y = carrot_length*sin(obj3wall_angle);
             frac_in_trans = 0;
         }
     }

--- a/src/napoleon_navigation_rosnode.cpp
+++ b/src/napoleon_navigation_rosnode.cpp
@@ -1324,7 +1324,6 @@ void createObstacleBoundingBox()
             }
         }
     }
-    update_obs =  false;
     if( update_obs )
     {
         no_obs = 1;

--- a/src/napoleon_navigation_rosnode.cpp
+++ b/src/napoleon_navigation_rosnode.cpp
@@ -2095,7 +2095,7 @@ int main(int argc, char** argv)
     unsigned int bufferSize = 2;
     ros::Subscriber scan_sub = nroshndl.subscribe<sensor_msgs::LaserScan>("scan", bufferSize, scanCallback);
 
-    napoleon_planner = new NapoleonPlanner("/ropod/goto");
+    napoleon_planner = new NapoleonPlanner("/napoleon/goto");
     napoleon_planner->start();
     while(nroshndl.ok())
     {

--- a/src/napoleon_navigation_rosnode.cpp
+++ b/src/napoleon_navigation_rosnode.cpp
@@ -232,7 +232,7 @@ void showWallPoints(Point local_wallpoint_front, Point local_wallpoint_rear,  ro
     //ROS_INFO_STREAM("showWallPoints (" << local_wallpoint_front.x  << ", " << local_wallpoint_front.y << "), ("
     //        << local_wallpoint_rear.x << ", " << local_wallpoint_rear.y << ")");
     visualization_msgs::Marker vis_wall;
-    vis_wall.header.frame_id = "ropod/base_link";
+    vis_wall.header.frame_id = "ropod_tue_2/base_link";
     vis_wall.header.stamp = ros::Time::now();
     // vis_points.ns = line_strip.ns = line_list.ns = "points_in_map";
     vis_wall.action = visualization_msgs::Marker::ADD;
@@ -1315,6 +1315,7 @@ void createObstacleBoundingBox()
             }
         }
     }
+    update_obs =  false;
     if( update_obs )
     {
         no_obs = 1;
@@ -2079,8 +2080,8 @@ int main(int argc, char** argv)
 
     ros::Subscriber goal_cmd_sub = nroshndl.subscribe<geometry_msgs::PoseStamped>("/route_navigation/simple_goal", 10, simpleGoalCallback);
     ros::Subscriber amcl_pose_sub = nroshndl.subscribe<geometry_msgs::PoseWithCovarianceStamped>("/amcl_pose", 10, getAmclPoseCallback);
-    ros::Subscriber ropod_odom_sub = nroshndl.subscribe<nav_msgs::Odometry>("/ropod/odom", 100, getOdomVelCallback);
-    ros::Subscriber ropod_debug_plan_sub = nroshndl.subscribe< ropod_ros_msgs::RoutePlannerResult >("/ropod/debug_route_plan", 1, getDebugRoutePlanCallback);
+    ros::Subscriber ropod_odom_sub = nroshndl.subscribe<nav_msgs::Odometry>("/ropod_tue_2/odom", 100, getOdomVelCallback);
+    ros::Subscriber ropod_debug_plan_sub = nroshndl.subscribe< ropod_ros_msgs::RoutePlannerResult >("/ropod_tue_2/debug_route_plan", 1, getDebugRoutePlanCallback);
 
     ros::Subscriber obstacle_sub = nroshndl.subscribe<ed_gui_server::objsPosVel>("/ed/gui/objectPosVel", 10, getObstaclesCallback);
     ros::Publisher vel_pub = nroshndl.advertise<geometry_msgs::Twist>("cmd_vel", 1);
@@ -2095,33 +2096,33 @@ int main(int argc, char** argv)
     unsigned int bufferSize = 2;
     ros::Subscriber scan_sub = nroshndl.subscribe<sensor_msgs::LaserScan>("scan", bufferSize, scanCallback);
 
-    napoleon_planner = new NapoleonPlanner("/ropod/goto");
-    napoleon_planner->start();
-    while(nroshndl.ok())
-    {
-        ROS_INFO("Wait for goto action");
-        while(ros::ok() && !napoleon_planner->getStatus())
-        {
-            ros::spinOnce();
-        }
-        std::vector<ropod_ros_msgs::Area> planner_areas = napoleon_planner->getPlannerResult().areas;
-
-        ROS_INFO("Got new route; following now");
-        followRoute(planner_areas, vel_pub, rate);
-    }
-
-    //ROS_INFO("Wait for debug plan on topic");
-    //while(ros::ok())
+    //napoleon_planner = new NapoleonPlanner("/ropod/goto");
+    //napoleon_planner->start();
+    //while(nroshndl.ok())
     //{
-        //if(start_navigation)
+        //ROS_INFO("Wait for goto action");
+        //while(ros::ok() && !napoleon_planner->getStatus())
         //{
-            //break;
+            //ros::spinOnce();
         //}
-        //ros::spinOnce();
+        //std::vector<ropod_ros_msgs::Area> planner_areas = napoleon_planner->getPlannerResult().areas;
+
+        //ROS_INFO("Got new route; following now");
+        //followRoute(planner_areas, vel_pub, rate);
     //}
-    //std::vector<ropod_ros_msgs::Area> planner_areas = debug_route_planner_result_.areas;
-    //ROS_INFO("Got new route; following now");
-    //followRoute(planner_areas, vel_pub, rate);
+
+    ROS_INFO("Wait for debug plan on topic");
+    while(ros::ok())
+    {
+        if(start_navigation)
+        {
+            break;
+        }
+        ros::spinOnce();
+    }
+    std::vector<ropod_ros_msgs::Area> planner_areas = debug_route_planner_result_.areas;
+    ROS_INFO("Got new route; following now");
+    followRoute(planner_areas, vel_pub, rate);
 
     // TODO: Make action serve and topic work non-blocking. For now I placed it here for not forgetting to change the laser topic as well
 

--- a/src/napoleon_navigation_rosnode.cpp
+++ b/src/napoleon_navigation_rosnode.cpp
@@ -1503,6 +1503,16 @@ public:
         status_ = status;
     }
 
+    void setSucceeded()
+    {
+        as_.setSucceeded();
+    }
+
+    void setAborted()
+    {
+        as_.setAborted();
+    }
+
     ropod_ros_msgs::RoutePlannerResult getPlannerResult()
     {
         return route_planner_result_;
@@ -2009,6 +2019,7 @@ void followRoute(std::vector<ropod_ros_msgs::Area> planner_areas,
 
                 // we reset the status so that we wait for another action request
                 napoleon_planner->setStatus(false);
+                napoleon_planner->setSucceeded();
             }
         }
 

--- a/yaml-cmds/napoleon_nav_plan_to_hochschulestrasse.yaml
+++ b/yaml-cmds/napoleon_nav_plan_to_hochschulestrasse.yaml
@@ -375,4 +375,4 @@ rostopic pub /ropod/goto/goal ropod_ros_msgs/GoToActionGoal "goal:
       start_floor: 0
       goal_floor: 0
       execution_status: ''
-      estimated_duration: 0.0"
+      estimated_duration: 0.0" -1

--- a/yaml-cmds/topic_ElevatorToFieldPlan.yaml
+++ b/yaml-cmds/topic_ElevatorToFieldPlan.yaml
@@ -1,0 +1,310 @@
+rostopic pub /ropod_tue_2/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas:
+    -
+      id: '1004'
+      name: 'H3'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas:
+        -
+          name: 'H3_1'
+          id: '104'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose:
+            position:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry:
+            vertices:
+              -
+                x: 5.70505
+                y: 7.06909
+                id: 8
+              -
+                x: 10.4967
+                y: 6.15313
+                id: 10
+              -
+                x: 10.9031
+                y: 7.72584
+                id: 11
+              -
+                x: 6.18012
+                y: 8.75905
+                id: 9
+          right:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          left:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          turn_point:
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '1003'
+      name: 'J2'
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'J2_1'
+          id: '103'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              -
+                x: 5.70505
+                y: 7.06909
+                id: 8
+              -
+                x: 6.18012
+                y: 8.75905
+                id: 9
+              -
+                x: 4.12461
+                y: 9.17959
+                id: 5
+              -
+                x: 3.56271
+                y: 7.38183
+                id: 4
+          right: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          left: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    -
+      id: '1002'
+      name: 'H2'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas:
+        -
+          name: 'H2_1'
+          id: '102'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose:
+            position:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry:
+            vertices:
+              -
+                x: 4.71307
+                y: 2.09019
+                id: 7
+              -
+                x: 5.70505
+                y: 7.06909
+                id: 8
+              -
+                x: 3.56271
+                y: 7.38183
+                id: 4
+              -
+                x: 2.25611
+                y: 2.41123
+                id: 3
+          right:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          left:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          turn_point:
+            x: 0.0
+            y: 0.0
+            id: 0
+    -
+      id: '1001'
+      name: 'J1'
+      type: 'junction'
+      floor_number: 0
+      sub_areas:
+        -
+          name: 'J1_1'
+          id: '101'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose:
+            position:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry:
+            vertices:
+              -
+                x: 1.92195
+                y: 0.799481
+                id: 2
+              -
+                x: 4.20596
+                y: -0.0657012
+                id: 6
+              -
+                x: 4.71307
+                y: 2.09019
+                id: 7
+              -
+                x: 2.25611
+                y: 2.41123
+                id: 3
+          right:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          left:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          turn_point:
+            x: 0.0
+            y: 0.0
+            id: 0
+    -
+      id: '1000'
+      name: 'H1'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas:
+        - name: 'H1_1'
+          id: '100'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose:
+            position:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry:
+            vertices:
+              -
+                x: -2.23141
+                y: 1.32531
+                id: 0
+              -
+                x: 1.92195
+                y: 0.799481
+                id: 2
+              -
+                x: 2.25611
+                y: 2.41123
+                id: 3
+              -
+                x: -1.82992
+                y: 3.3041
+                id: 1
+          right:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          left:
+            point1:
+              x: 0
+              y: 0
+              id: 0
+            point2:
+              x: 0
+              y: 0
+              id: 0
+          turn_point:
+            x: 0.0
+            y: 0.0
+            id: 0" -1

--- a/yaml-cmds/topic_ElevatorToFieldPlan.yaml
+++ b/yaml-cmds/topic_ElevatorToFieldPlan.yaml
@@ -1,4 +1,4 @@
-rostopic pub /ropod_tue_2/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas:
+rostopic pub /ropod/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas:
     -
       id: '1004'
       name: 'H3'

--- a/yaml-cmds/topic_FieldToElevatorPlan.yaml
+++ b/yaml-cmds/topic_FieldToElevatorPlan.yaml
@@ -1,0 +1,311 @@
+rostopic pub /ropod_tue_2/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas: 
+    - 
+      id: '1000'
+      name: 'H1'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'H1_1'
+          id: '100'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              -
+                x: -2.23141
+                y: 1.32531
+                id: 0
+              -
+                x: 1.92195
+                y: 0.799481
+                id: 2
+              -
+                x: 2.25611
+                y: 2.41123
+                id: 3
+              -
+                x: -1.82992
+                y: 3.3041
+                id: 1
+          right: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          left: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '1001'
+      name: 'J1'
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'J1_1'
+          id: '101'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              -
+                x: 1.92195
+                y: 0.799481
+                id: 2
+              -
+                x: 4.20596
+                y: -0.0657012
+                id: 6
+              -
+                x: 4.71307
+                y: 2.09019
+                id: 7
+              -
+                x: 2.25611
+                y: 2.41123
+                id: 3
+          right: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          left: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '1002'
+      name: 'H2'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'H2_1'
+          id: '102'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              -
+                x: 4.71307
+                y: 2.09019
+                id: 7
+              -
+                x: 5.70505
+                y: 7.06909
+                id: 8
+              -
+                x: 3.56271
+                y: 7.38183
+                id: 4
+              -
+                x: 2.25611
+                y: 2.41123
+                id: 3
+          right: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          left: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '1003'
+      name: 'J2'
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'J2_1'
+          id: '103'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              -
+                x: 5.70505
+                y: 7.06909
+                id: 8
+              -
+                x: 6.18012
+                y: 8.75905
+                id: 9
+              -
+                x: 4.12461
+                y: 9.17959
+                id: 5
+              -
+                x: 3.56271
+                y: 7.38183
+                id: 4
+          right: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          left: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '1004'
+      name: 'H3'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'H3_1'
+          id: '104'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              -
+                x: 5.70505
+                y: 7.06909
+                id: 8
+              -
+                x: 10.4967
+                y: 6.15313
+                id: 10
+              -
+                x: 10.9031
+                y: 7.72584
+                id: 11
+              -
+                x: 6.18012
+                y: 8.75905
+                id: 9
+          right: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          left: 
+            point1: 
+              x: 0
+              y: 0
+              id: 0
+            point2: 
+              x: 0
+              y: 0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0" -1

--- a/yaml-cmds/topic_FieldToElevatorPlan.yaml
+++ b/yaml-cmds/topic_FieldToElevatorPlan.yaml
@@ -1,4 +1,4 @@
-rostopic pub /ropod_tue_2/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas: 
+rostopic pub /ropod/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas: 
     - 
       id: '1000'
       name: 'H1'

--- a/yaml-cmds/topic_napoleon_nav_plan_to_hochschulestrasse.yaml
+++ b/yaml-cmds/topic_napoleon_nav_plan_to_hochschulestrasse.yaml
@@ -1,0 +1,2187 @@
+rostopic pub /ropod/debug_route_plan ropod_ros_msgs/RoutePlannerResult "areas:
+    - 
+      id: '5'
+      name: 'BRSU_C_L0_C9'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'BRSU_C_L0_C9_LA1'
+          id: '61'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 63.395690918
+                y: 33.1979217529
+                id: 1571
+              - 
+                x: 54.3451690674
+                y: 33.4537239075
+                id: 1570
+              - 
+                x: 54.3025970459
+                y: 32.0084457397
+                id: 1572
+              - 
+                x: 63.3531188965
+                y: 31.7526473999
+                id: 1573
+          right: 
+            point1: 
+              x: 54.3025970459
+              y: 32.0084457397
+              id: 1572
+            point2: 
+              x: 63.3531188965
+              y: 31.7526473999
+              id: 1573
+          left: 
+            point1: 
+              x: 54.3451690674
+              y: 33.4537239075
+              id: 1570
+            point2: 
+              x: 63.395690918
+              y: 33.1979217529
+              id: 1571
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 54.3451690674
+                y: 33.4537239075
+                id: 1570
+              - 
+                x: 53.0334472656
+                y: 33.4637107849
+                id: 1595
+              - 
+                x: 53.4655265808
+                y: 31.5283699036
+                id: 1594
+              - 
+                x: 54.3025970459
+                y: 32.0084457397
+                id: 1572
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '7'
+      name: 'BRSU_C_L0_C8'
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'BRSU_C_L0_C8_LA1'
+          id: '64'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 53.0334472656
+                y: 33.4637107849
+                id: 1595
+              - 
+                x: 50.4813156128
+                y: 33.5153083801
+                id: 1596
+              - 
+                x: 50.9491882324
+                y: 31.6013393402
+                id: 1593
+              - 
+                x: 53.4655265808
+                y: 31.5283699036
+                id: 1594
+          right: 
+            point1: 
+              x: 50.9491882324
+              y: 31.6013393402
+              id: 1593
+            point2: 
+              x: 53.4655265808
+              y: 31.5283699036
+              id: 1594
+          left: 
+            point1: 
+              x: 50.4813156128
+              y: 33.5153083801
+              id: 1596
+            point2: 
+              x: 53.0334472656
+              y: 33.4637107849
+              id: 1595
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '92'
+      name: 'BRSU_C_L0_C7'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 50.4813156128
+                y: 33.5153083801
+                id: 1596
+              - 
+                x: 50.1147499084
+                y: 33.5243186951
+                id: 1601
+              - 
+                x: 50.0909767151
+                y: 32.5569801331
+                id: 1600
+              - 
+                x: 50.9491882324
+                y: 31.6013393402
+                id: 1593
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: 'BRSU_C_L0_C7_LA1'
+          id: '66'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 50.1147499084
+                y: 33.5243186951
+                id: 1601
+              - 
+                x: 40.239730835
+                y: 33.8115310669
+                id: 1602
+              - 
+                x: 40.2089080811
+                y: 32.844367981
+                id: 1599
+              - 
+                x: 50.0909767151
+                y: 32.5569801331
+                id: 1600
+          right: 
+            point1: 
+              x: 40.2089080811
+              y: 32.844367981
+              id: 1599
+            point2: 
+              x: 50.0909767151
+              y: 32.5569801331
+              id: 1600
+          left: 
+            point1: 
+              x: 40.239730835
+              y: 33.8115310669
+              id: 1602
+            point2: 
+              x: 50.1147499084
+              y: 33.5243186951
+              id: 1601
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 40.239730835
+                y: 33.8115310669
+                id: 1602
+              - 
+                x: 39.6828346252
+                y: 33.8252220154
+                id: 1607
+              - 
+                x: 39.6590576172
+                y: 32.8578834534
+                id: 1606
+              - 
+                x: 40.2089080811
+                y: 32.844367981
+                id: 1599
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '8'
+      name: 'BRSU_C_L0_C6'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'BRSU_C_L0_C6_LA1'
+          id: '68'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 39.6828346252
+                y: 33.8252220154
+                id: 1607
+              - 
+                x: 24.6327877045
+                y: 34.2062911987
+                id: 1608
+              - 
+                x: 24.6090087891
+                y: 33.2389526367
+                id: 1605
+              - 
+                x: 39.6590576172
+                y: 32.8578834534
+                id: 1606
+          right: 
+            point1: 
+              x: 24.6090087891
+              y: 33.2389526367
+              id: 1605
+            point2: 
+              x: 39.6590576172
+              y: 32.8578834534
+              id: 1606
+          left: 
+            point1: 
+              x: 24.6327877045
+              y: 34.2062911987
+              id: 1608
+            point2: 
+              x: 39.6828346252
+              y: 33.8252220154
+              id: 1607
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 24.6327877045
+                y: 34.2062911987
+                id: 1608
+              - 
+                x: 23.3354377747
+                y: 34.2270584106
+                id: 1613
+              - 
+                x: 23.3043365479
+                y: 33.2487716675
+                id: 1612
+              - 
+                x: 24.6090087891
+                y: 33.2389526367
+                id: 1605
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '9'
+      name: 'BRSU_C_L0_C5'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'BRSU_C_L0_C5_LA1'
+          id: '70'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 23.3354377747
+                y: 34.2270584106
+                id: 1613
+              - 
+                x: 8.09615421295
+                y: 34.6573295593
+                id: 1614
+              - 
+                x: 8.07182407379
+                y: 33.6677513123
+                id: 1611
+              - 
+                x: 23.3043365479
+                y: 33.2487716675
+                id: 1612
+          right: 
+            point1: 
+              x: 8.07182407379
+              y: 33.6677513123
+              id: 1611
+            point2: 
+              x: 23.3043365479
+              y: 33.2487716675
+              id: 1612
+          left: 
+            point1: 
+              x: 8.09615421295
+              y: 34.6573295593
+              id: 1614
+            point2: 
+              x: 23.3354377747
+              y: 34.2270584106
+              id: 1613
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 8.09615421295
+                y: 34.6573295593
+                id: 1614
+              - 
+                x: 7.80172204971
+                y: 34.7313194275
+                id: 1619
+              - 
+                x: 7.78252840042
+                y: 33.6637382507
+                id: 1618
+              - 
+                x: 8.07182407379
+                y: 33.6677513123
+                id: 1611
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '10'
+      name: 'BRSU_C_L0_C4'
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'BRSU_C_L0_C4_LA1'
+          id: '72'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 7.80172204971
+                y: 34.7313194275
+                id: 1619
+              - 
+                x: 5.49467754364
+                y: 34.7101631165
+                id: 1620
+              - 
+                x: 5.45624923706
+                y: 33.7209320068
+                id: 1617
+              - 
+                x: 7.78252840042
+                y: 33.6637382507
+                id: 1618
+          right: 
+            point1: 
+              x: 5.45624923706
+              y: 33.7209320068
+              id: 1617
+            point2: 
+              x: 7.78252840042
+              y: 33.6637382507
+              id: 1618
+          left: 
+            point1: 
+              x: 5.49467754364
+              y: 34.7101631165
+              id: 1620
+            point2: 
+              x: 7.80172204971
+              y: 34.7313194275
+              id: 1619
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 5.49467754364
+                y: 34.7101631165
+                id: 1620
+              - 
+                x: 3.90994524956
+                y: 34.8047523499
+                id: 1623
+              - 
+                x: 3.85745787621
+                y: 32.6699371338
+                id: 1622
+              - 
+                x: 5.45624923706
+                y: 33.7209320068
+                id: 1617
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '12'
+      name: 'BRSU_C_L0_C2'
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: 'BRSU_C_L0_C2_LA1'
+          id: '75'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 0.942177534103
+                y: 34.8777198792
+                id: 1624
+              - 
+                x: 0.854168891907
+                y: 32.7326507568
+                id: 1621
+              - 
+                x: 3.85745787621
+                y: 32.6699371338
+                id: 1622
+              - 
+                x: 3.90994524956
+                y: 34.8047523499
+                id: 1623
+          right: 
+            point1: 
+              x: 3.85745787621
+              y: 32.6699371338
+              id: 1622
+            point2: 
+              x: 3.90994524956
+              y: 34.8047523499
+              id: 1623
+          left: 
+            point1: 
+              x: 0.854168891907
+              y: 32.7326507568
+              id: 1621
+            point2: 
+              x: 0.942177534103
+              y: 34.8777198792
+              id: 1624
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '13'
+      name: ''
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 0.854168891907
+                y: 32.7326507568
+                id: 1621
+              - 
+                x: 0.913610160351
+                y: 31.7076377869
+                id: 1627
+              - 
+                x: 1.90024352074
+                y: 31.6722545624
+                id: 1628
+              - 
+                x: 3.85745787621
+                y: 32.6699371338
+                id: 1622
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: '77'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 0.913610160351
+                y: 31.7076377869
+                id: 1627
+              - 
+                x: 0.773406863213
+                y: 24.8577384949
+                id: 1630
+              - 
+                x: 1.76736426353
+                y: 24.8333015442
+                id: 1629
+              - 
+                x: 1.90024352074
+                y: 31.6722545624
+                id: 1628
+          right: 
+            point1: 
+              x: 1.76736426353
+              y: 24.8333015442
+              id: 1629
+            point2: 
+              x: 1.90024352074
+              y: 31.6722545624
+              id: 1628
+          left: 
+            point1: 
+              x: 0.773406863213
+              y: 24.8577384949
+              id: 1630
+            point2: 
+              x: 0.913610160351
+              y: 31.7076377869
+              id: 1627
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 0.773406863213
+                y: 24.8577384949
+                id: 1630
+              - 
+                x: 0.599165856838
+                y: 22.6480369568
+                id: 1473
+              - 
+                x: 2.79938197136
+                y: 22.6273174286
+                id: 1472
+              - 
+                x: 1.76736426353
+                y: 24.8333015442
+                id: 1629
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '123'
+      name: ''
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '117'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 0.599165856838
+                y: 22.6480369568
+                id: 1473
+              - 
+                x: 0.525568783283
+                y: 19.367805481
+                id: 1470
+              - 
+                x: 2.71141433716
+                y: 19.3363132477
+                id: 1471
+              - 
+                x: 2.79938197136
+                y: 22.6273174286
+                id: 1472
+          right: 
+            point1: 
+              x: 2.71141433716
+              y: 19.3363132477
+              id: 1471
+            point2: 
+              x: 2.79938197136
+              y: 22.6273174286
+              id: 1472
+          left: 
+            point1: 
+              x: 0.525568783283
+              y: 19.367805481
+              id: 1470
+            point2: 
+              x: 0.599165856838
+              y: 22.6480369568
+              id: 1473
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '124'
+      name: ''
+      type: 'area'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: 0.525568783283
+                y: 19.367805481
+                id: 1470
+              - 
+                x: -0.519355297089
+                y: 16.7456130981
+                id: 1469
+              - 
+                x: 3.56954360008
+                y: 16.656206131
+                id: 1468
+              - 
+                x: 2.71141433716
+                y: 19.3363132477
+                id: 1471
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: '118'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -0.519355297089
+                y: 16.7456130981
+                id: 1469
+              - 
+                x: -0.657040715218
+                y: 10.2850475311
+                id: 1466
+              - 
+                x: 3.43186330795
+                y: 10.195640564
+                id: 1467
+              - 
+                x: 3.56954360008
+                y: 16.656206131
+                id: 1468
+          right: 
+            point1: 
+              x: 3.43186330795
+              y: 10.195640564
+              id: 1467
+            point2: 
+              x: 3.56954360008
+              y: 16.656206131
+              id: 1468
+          left: 
+            point1: 
+              x: -0.657040715218
+              y: 10.2850475311
+              id: 1466
+            point2: 
+              x: -0.519355297089
+              y: 16.7456130981
+              id: 1469
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -0.657040715218
+                y: 10.2850475311
+                id: 1466
+              - 
+                x: -0.648526549339
+                y: 9.48379802704
+                id: 1465
+              - 
+                x: 3.42709946632
+                y: 9.42809391022
+                id: 1464
+              - 
+                x: 3.43186330795
+                y: 10.195640564
+                id: 1467
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '126'
+      name: ''
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '119'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: 3.42709946632
+                y: 9.42809391022
+                id: 1464
+              - 
+                x: -0.648526549339
+                y: 9.48379802704
+                id: 1465
+              - 
+                x: -0.705466985703
+                y: 5.44661903381
+                id: 1462
+              - 
+                x: 3.37721157074
+                y: 5.3907418251
+                id: 1463
+          right: 
+            point1: 
+              x: -0.705466985703
+              y: 5.44661903381
+              id: 1462
+            point2: 
+              x: 3.37721157074
+              y: 5.3907418251
+              id: 1463
+          left: 
+            point1: 
+              x: -0.648526549339
+              y: 9.48379802704
+              id: 1465
+            point2: 
+              x: 3.42709946632
+              y: 9.42809391022
+              id: 1464
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '272'
+      name: ''
+      type: 'area'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -0.648526549339
+                y: 9.48379802704
+                id: 1465
+              - 
+                x: -1.89981794357
+                y: 9.36993122101
+                id: 3279
+              - 
+                x: -2.0236594677
+                y: 0.316769212484
+                id: 3280
+              - 
+                x: -0.705466985703
+                y: 5.44661903381
+                id: 1462
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: '263'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -1.89981794357
+                y: 9.36993122101
+                id: 3279
+              - 
+                x: -7.87931919098
+                y: 9.45020103455
+                id: 3282
+              - 
+                x: -8.19432449341
+                y: 0.368362307549
+                id: 3281
+              - 
+                x: -2.0236594677
+                y: 0.316769212484
+                id: 3280
+          right: 
+            point1: 
+              x: -8.19432449341
+              y: 0.368362307549
+              id: 3281
+            point2: 
+              x: -2.0236594677
+              y: 0.316769212484
+              id: 3280
+          left: 
+            point1: 
+              x: -7.87931919098
+              y: 9.45020103455
+              id: 3282
+            point2: 
+              x: -1.89981794357
+              y: 9.36993122101
+              id: 3279
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -7.87931919098
+                y: 9.45020103455
+                id: 3282
+              - 
+                x: -10.9443950653
+                y: 4.41893386841
+                id: 3268
+              - 
+                x: -11.0153608322
+                y: 2.1065621376
+                id: 3269
+              - 
+                x: -8.19432449341
+                y: 0.368362307549
+                id: 3281
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '274'
+      name: ''
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '262'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -10.9443950653
+                y: 4.41893386841
+                id: 3268
+              - 
+                x: -12.7287063599
+                y: 4.42943191528
+                id: 3267
+              - 
+                x: -12.813498497
+                y: 2.12852573395
+                id: 3270
+              - 
+                x: -11.0153608322
+                y: 2.1065621376
+                id: 3269
+          right: 
+            point1: 
+              x: -12.813498497
+              y: 2.12852573395
+              id: 3270
+            point2: 
+              x: -11.0153608322
+              y: 2.1065621376
+              id: 3269
+          left: 
+            point1: 
+              x: -12.7287063599
+              y: 4.42943191528
+              id: 3267
+            point2: 
+              x: -10.9443950653
+              y: 4.41893386841
+              id: 3268
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '276'
+      name: ''
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -12.7287063599
+                y: 4.42943191528
+                id: 3267
+              - 
+                x: -16.6495227814
+                y: 4.47021579742
+                id: 3266
+              - 
+                x: -16.6779594421
+                y: 3.31385660172
+                id: 3263
+              - 
+                x: -12.813498497
+                y: 2.12852573395
+                id: 3270
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: '261'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -16.6495227814
+                y: 4.47021579742
+                id: 3266
+              - 
+                x: -37.339641571
+                y: 5.25716733932
+                id: 3265
+              - 
+                x: -37.3822402954
+                y: 3.81189155579
+                id: 3264
+              - 
+                x: -16.6779594421
+                y: 3.31385660172
+                id: 3263
+          right: 
+            point1: 
+              x: -37.3822402954
+              y: 3.81189155579
+              id: 3264
+            point2: 
+              x: -16.6779594421
+              y: 3.31385660172
+              id: 3263
+          left: 
+            point1: 
+              x: -37.339641571
+              y: 5.25716733932
+              id: 3265
+            point2: 
+              x: -16.6495227814
+              y: 4.47021579742
+              id: 3266
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -37.339641571
+                y: 5.25716733932
+                id: 3265
+              - 
+                x: -38.0857810974
+                y: 5.32002019882
+                id: 3257
+              - 
+                x: -38.1182899475
+                y: 2.85094451904
+                id: 3260
+              - 
+                x: -37.3822402954
+                y: 3.81189155579
+                id: 3264
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '268'
+      name: ''
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '259'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -38.0857810974
+                y: 5.32002019882
+                id: 3257
+              - 
+                x: -45.2658691406
+                y: 5.34085559845
+                id: 3258
+              - 
+                x: -45.375377655
+                y: 2.89592456818
+                id: 3259
+              - 
+                x: -38.1182899475
+                y: 2.85094451904
+                id: 3260
+          right: 
+            point1: 
+              x: -45.375377655
+              y: 2.89592456818
+              id: 3259
+            point2: 
+              x: -38.1182899475
+              y: 2.85094451904
+              id: 3260
+          left: 
+            point1: 
+              x: -45.2658691406
+              y: 5.34085559845
+              id: 3258
+            point2: 
+              x: -38.0857810974
+              y: 5.32002019882
+              id: 3257
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -45.2658691406
+                y: 5.34085559845
+                id: 3258
+              - 
+                x: -47.7013969421
+                y: 5.5453915596
+                id: 3256
+              - 
+                x: -47.7333908081
+                y: 4.24448728561
+                id: 3253
+              - 
+                x: -45.375377655
+                y: 2.89592456818
+                id: 3259
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '267'
+      name: ''
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '258'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -47.7013969421
+                y: 5.5453915596
+                id: 3256
+              - 
+                x: -60.0236930847
+                y: 5.84848546982
+                id: 3255
+              - 
+                x: -60.0340003967
+                y: 4.56929922104
+                id: 3254
+              - 
+                x: -47.7333908081
+                y: 4.24448728561
+                id: 3253
+          right: 
+            point1: 
+              x: -60.0340003967
+              y: 4.56929922104
+              id: 3254
+            point2: 
+              x: -47.7333908081
+              y: 4.24448728561
+              id: 3253
+          left: 
+            point1: 
+              x: -60.0236930847
+              y: 5.84848546982
+              id: 3255
+            point2: 
+              x: -47.7013969421
+              y: 5.5453915596
+              id: 3256
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -60.0236930847
+                y: 5.84848546982
+                id: 3255
+              - 
+                x: -60.8318481445
+                y: 6.25776004791
+                id: 3231
+              - 
+                x: -60.8997421265
+                y: 3.2110247612
+                id: 3232
+              - 
+                x: -60.0340003967
+                y: 4.56929922104
+                id: 3254
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '278'
+      name: ''
+      type: 'junction'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '252'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -60.8318481445
+                y: 6.25776004791
+                id: 3231
+              - 
+                x: -73.0503234863
+                y: 6.4804520607
+                id: 3230
+              - 
+                x: -73.1501846313
+                y: 3.56800985336
+                id: 3233
+              - 
+                x: -60.8997421265
+                y: 3.2110247612
+                id: 3232
+          right: 
+            point1: 
+              x: -73.1501846313
+              y: 3.56800985336
+              id: 3233
+            point2: 
+              x: -60.8997421265
+              y: 3.2110247612
+              id: 3232
+          left: 
+            point1: 
+              x: -73.0503234863
+              y: 6.4804520607
+              id: 3230
+            point2: 
+              x: -60.8318481445
+              y: 6.25776004791
+              id: 3231
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '273'
+      name: ''
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -73.0503234863
+                y: 6.4804520607
+                id: 3230
+              - 
+                x: -76.3949432373
+                y: 6.71849155426
+                id: 3225
+              - 
+                x: -76.4559631348
+                y: 5.38492488861
+                id: 3227
+              - 
+                x: -73.1501846313
+                y: 3.56800985336
+                id: 3233
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: '251'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -76.3949432373
+                y: 6.71849155426
+                id: 3225
+              - 
+                x: -81.8020858765
+                y: 6.84039258957
+                id: 3224
+              - 
+                x: -81.8305969238
+                y: 5.39477014542
+                id: 3226
+              - 
+                x: -76.4559631348
+                y: 5.38492488861
+                id: 3227
+          right: 
+            point1: 
+              x: -81.8305969238
+              y: 5.39477014542
+              id: 3226
+            point2: 
+              x: -76.4559631348
+              y: 5.38492488861
+              id: 3227
+          left: 
+            point1: 
+              x: -81.8020858765
+              y: 6.84039258957
+              id: 3224
+            point2: 
+              x: -76.3949432373
+              y: 6.71849155426
+              id: 3225
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+        - 
+          name: ''
+          id: ''
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 0.0
+          geometry: 
+            vertices: 
+              - 
+                x: -81.8020858765
+                y: 6.84039258957
+                id: 3224
+              - 
+                x: -83.8038330078
+                y: 6.90076684952
+                id: 3223
+              - 
+                x: -83.8369903564
+                y: 5.2661242485
+                id: 3220
+              - 
+                x: -81.8305969238
+                y: 5.39477014542
+                id: 3226
+          right: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          left: 
+            point1: 
+              x: 0.0
+              y: 0.0
+              id: 0
+            point2: 
+              x: 0.0
+              y: 0.0
+              id: 0
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0
+    - 
+      id: '281'
+      name: ''
+      type: 'corridor'
+      floor_number: 0
+      sub_areas: 
+        - 
+          name: ''
+          id: '249'
+          floor_number: 0
+          type: ''
+          capacity: 0
+          waypoint_pose: 
+            position: 
+              x: -1.0
+              y: -1.0
+              z: 0.0
+            orientation: 
+              x: 0.0
+              y: 0.0
+              z: 0.0
+              w: 1.0
+          geometry: 
+            vertices: 
+              - 
+                x: -83.8038330078
+                y: 6.90076684952
+                id: 3223
+              - 
+                x: -95.7918624878
+                y: 7.02883815765
+                id: 3222
+              - 
+                x: -95.8483047485
+                y: 5.59502840042
+                id: 3221
+              - 
+                x: -83.8369903564
+                y: 5.2661242485
+                id: 3220
+          right: 
+            point1: 
+              x: -95.8483047485
+              y: 5.59502840042
+              id: 3221
+            point2: 
+              x: -83.8369903564
+              y: 5.2661242485
+              id: 3220
+          left: 
+            point1: 
+              x: -95.7918624878
+              y: 7.02883815765
+              id: 3222
+            point2: 
+              x: -83.8038330078
+              y: 6.90076684952
+              id: 3223
+          turn_point: 
+            x: 0.0
+            y: 0.0
+            id: 0" -1


### PR DESCRIPTION
This PR:
* introduces various changes to the obstacle avoidance behaviour (merged here from the `test/tue` branch)
* changes the name of the `goto` action server to `/napoleon/goto` (we have integrated the napoleon navigation with the new navigation mediator, which is the one listening to `/ropod/goto`)
* sets the status of the `goto` action server after the completion of the action (also required by the navigation mediator and the experiment executor)